### PR TITLE
feat: add isGated variable to users.

### DIFF
--- a/frontend/app/(authenticated)/profile/[wallet]/edit/page.tsx
+++ b/frontend/app/(authenticated)/profile/[wallet]/edit/page.tsx
@@ -12,7 +12,7 @@ import { useUserProfile } from "@/hooks/useUserProfile";
 import { USER_BIO_MAX_LENGTH } from "@/lib/constants";
 import { formatError, shortAddress } from "@/lib/utils";
 import { RefreshOutlined } from "@mui/icons-material";
-import { Avatar, Button, Card, Chip, Link as JoyLink, Textarea, Typography } from "@mui/joy";
+import { Avatar, Button, Card, Chip, Link as JoyLink, Switch, Textarea, Typography } from "@mui/joy";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
@@ -25,6 +25,7 @@ export default function EditProfilePage() {
   const [bio, setBio] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
   const [isReady, setIsready] = useState(false);
+  const [isGated, setIsGated] = useState<boolean>(profile.user?.isGated || true);
 
   useEffect(() => {
     if (currentUser && !isReady) {
@@ -40,7 +41,7 @@ export default function EditProfilePage() {
   const handleSaveProfile = async () => {
     setIsLoading(true);
     await updateUser
-      .mutateAsync({ tags: selectedTags, bio: bio })
+      .mutateAsync({ tags: selectedTags, bio: bio, isGated })
       .then(async () => {
         toast.success("Profile updated");
         await Promise.allSettled([profile.refetch(), refetch()]);
@@ -167,6 +168,12 @@ export default function EditProfilePage() {
         <Typography color={selectedTags.length > 3 ? "danger" : undefined} level="helper">
           {selectedTags.length}/3
         </Typography>
+      </Flex>
+      <Flex y gap1>
+        <Flex x gap2>
+          <Switch checked={isGated} onChange={e => setIsGated(e.target.checked)} />
+          <Typography>Disallow users to ask you questions without your key</Typography>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/frontend/app/(authenticated)/profile/[wallet]/edit/page.tsx
+++ b/frontend/app/(authenticated)/profile/[wallet]/edit/page.tsx
@@ -172,7 +172,7 @@ export default function EditProfilePage() {
       <Flex y gap1>
         <Flex x gap2>
           <Switch checked={isGated} onChange={e => setIsGated(e.target.checked)} />
-          <Typography>Disallow users to ask you questions without your key</Typography>
+          <Typography>Require users to have your key to ask you questions</Typography>
         </Flex>
       </Flex>
     </Flex>

--- a/frontend/backend/question/question.ts
+++ b/frontend/backend/question/question.ts
@@ -89,7 +89,7 @@ export const createQuestion = async (
 
   if (replier.keysOfSelf && replier.keysOfSelf.length > 0) {
     const key = questioner.keysOwned.find(key => key.ownerId === replierId);
-    if (!key || key.amount === BigInt(0)) {
+    if (replier.isGated && (!key || key.amount === BigInt(0))) {
       return { error: ERRORS.MUST_HOLD_KEY };
     }
   }
@@ -220,8 +220,8 @@ export async function getHotQuestions(offset: number, filters: { questionerId?: 
       replier."displayName" AS "replierDisplayName",
       replier."avatarUrl" AS "replierAvatarUrl",
       replier."wallet" AS "replierWallet",
-      COALESCE(SUM(CASE WHEN r."reactionType" = 'UPVOTE' THEN 1 ELSE 0 END), 0) 
-      - COALESCE(SUM(CASE WHEN r."reactionType" = 'DOWNVOTE' THEN 1 ELSE 0 END), 0) 
+      COALESCE(SUM(CASE WHEN r."reactionType" = 'UPVOTE' THEN 1 ELSE 0 END), 0)
+      - COALESCE(SUM(CASE WHEN r."reactionType" = 'DOWNVOTE' THEN 1 ELSE 0 END), 0)
       AS net_upvotes,
       STRING_AGG(t.name, ', ') AS tags
     FROM

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   updatedAt                   DateTime                  @updatedAt
   lastRecommendationsSyncedAt DateTime?
   bio                         String?                   @db.VarChar(500)
+  isGated                     Boolean                   @default(true)
   comments                    Comment[]
   inviteCodes                 InviteCode[]
   keysOwned                   KeyRelationship[]         @relation("holder")


### PR DESCRIPTION
This commit adds the following changes:
- Users now have a `isGated` boolean field (defaults to `true`). When is set to false, users can create questions towards that particular user even if they don't have the key;
- A switch field in the `EditProfilePage` so users can toggle such variable.

Don't know if the copy on the switch is the best tbh, let me know if it's better to write something else.

(PS. don't know why but my editor removed some white spaces in some raw sql queries)